### PR TITLE
Add dark mode toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@ const answerElement = document.getElementById('answer');
 const showAnswerBtn = document.getElementById('show-answer');
 const difficultyButtons = document.querySelectorAll('.difficulty-btn');
 const backToHomeBtn = document.getElementById('back-to-home');
+const themeToggleBtn = document.getElementById('theme-toggle');
 
 // State
 let currentDeck = [];
@@ -56,6 +57,7 @@ let currentSpecialty = '';
 function init() {
     loadDecks();
     setupEventListeners();
+    loadTheme();
     updateProgress();
 }
 
@@ -94,6 +96,9 @@ function setupEventListeners() {
     
     // Back to home button
     backToHomeBtn.addEventListener('click', showHomeScreen);
+
+    // Theme toggle button
+    themeToggleBtn.addEventListener('click', toggleTheme);
 }
 
 // Start a study session for a specific specialty
@@ -214,6 +219,22 @@ function shuffleArray(array) {
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;
+}
+
+// Theme handling
+function loadTheme() {
+    const theme = localStorage.getItem('theme') || 'light';
+    if (theme === 'dark') {
+        document.body.classList.add('dark-mode');
+        themeToggleBtn.querySelector('i').classList.replace('fa-moon', 'fa-sun');
+    }
+}
+
+function toggleTheme() {
+    const isDark = document.body.classList.toggle('dark-mode');
+    themeToggleBtn.querySelector('i').classList.toggle('fa-sun', isDark);
+    themeToggleBtn.querySelector('i').classList.toggle('fa-moon', !isDark);
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
 }
 
 // Sample data (you'll replace this with your actual data)

--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <button id="theme-toggle" class="icon-btn" aria-label="Cambiar modo">
+        <i class="fas fa-moon"></i>
+    </button>
     <div id="app">
         <!-- Home Screen -->
         <div id="home-screen">

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,20 @@ body {
     line-height: 1.6;
 }
 
+.icon-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: #7f8c8d;
+    cursor: pointer;
+}
+
+#theme-toggle {
+    position: fixed;
+    right: 1rem;
+    top: 1rem;
+}
+
 .hidden {
     display: none !important;
 }
@@ -207,6 +221,35 @@ h1 {
 .difficulty-btn[data-difficulty="3"] {
     background-color: #2ecc71;
     color: white;
+}
+
+/* Dark Mode Styles */
+body.dark-mode {
+    background-color: #2c3e50;
+    color: #ecf0f1;
+}
+
+body.dark-mode header {
+    border-bottom-color: #34495e;
+}
+
+body.dark-mode .specialty-btn {
+    background: #34495e;
+    color: #ecf0f1;
+    border-color: #ecf0f1;
+}
+
+body.dark-mode .specialty-btn i {
+    color: #ecf0f1;
+}
+
+body.dark-mode #flashcard {
+    background: #34495e;
+    color: #ecf0f1;
+}
+
+body.dark-mode #progress-bar {
+    background-color: #34495e;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- add dark mode toggle button
- style button and create dark-mode classes
- implement theme persistence and toggle logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f02949524832890d99d523e7efa44