### PR TITLE
Improve home screen appearance

### DIFF
--- a/app.js
+++ b/app.js
@@ -208,8 +208,12 @@ function updateProgress() {
     
     // Update progress bar
     const progress = totalCards > 0 ? ((totalCards - dueCards) / totalCards) * 100 : 0;
-    progressFill.style.width = `${progress}%`;
-    progressText.textContent = `${dueCards} tarjeta${dueCards !== 1 ? 's' : ''} por repasar hoy`;
+    if (window.updateProgressUI) {
+        window.updateProgressUI(progress, dueCards);
+    } else {
+        progressFill.style.width = `${progress}%`;
+        progressText.textContent = `${dueCards} tarjeta${dueCards !== 1 ? 's' : ''} por repasar hoy`;
+    }
 }
 
 // Utility function to shuffle an array
@@ -226,12 +230,14 @@ function loadTheme() {
     const theme = localStorage.getItem('theme') || 'light';
     if (theme === 'dark') {
         document.body.classList.add('dark-mode');
+        document.body.classList.add('dark');
         themeToggleBtn.querySelector('i').classList.replace('fa-moon', 'fa-sun');
     }
 }
 
 function toggleTheme() {
     const isDark = document.body.classList.toggle('dark-mode');
+    document.body.classList.toggle('dark', isDark);
     themeToggleBtn.querySelector('i').classList.toggle('fa-sun', isDark);
     themeToggleBtn.querySelector('i').classList.toggle('fa-moon', !isDark);
     localStorage.setItem('theme', isDark ? 'dark' : 'light');

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
     <title>Repaso Médico</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
+    <script src="https://unpkg.com/lucide-react/dist/lucide-react.umd.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body>
     <button id="theme-toggle" class="icon-btn" aria-label="Cambiar modo">
@@ -16,41 +25,9 @@
         <div id="home-screen">
             <header>
                 <h1>Repaso Médico</h1>
-                <div id="progress-container">
-                    <div id="progress-bar">
-                        <div id="progress-fill"></div>
-                    </div>
-                    <div id="progress-text">0/0 tarjetas hoy</div>
-                </div>
             </header>
-            
             <main>
-                <div class="specialty-grid">
-                    <button class="specialty-btn" data-specialty="medicina">
-                        <i class="fas fa-stethoscope"></i>
-                        <span>Medicina Interna</span>
-                    </button>
-                    <button class="specialty-btn" data-specialty="cirugia">
-                        <i class="fas fa-syringe"></i>
-                        <span>Cirugía</span>
-                    </button>
-                    <button class="specialty-btn" data-specialty="pediatria">
-                        <i class="fas fa-baby"></i>
-                        <span>Pediatría</span>
-                    </button>
-                    <button class="specialty-btn" data-specialty="ginecologia">
-                        <i class="fas fa-female"></i>
-                        <span>Ginecología y Obstetricia</span>
-                    </button>
-                    <button class="specialty-btn" data-specialty="atls">
-                        <i class="fas fa-ambulance"></i>
-                        <span>ATLS</span>
-                    </button>
-                    <button class="specialty-btn" data-specialty="acls">
-                        <i class="fas fa-heartbeat"></i>
-                        <span>ACLS</span>
-                    </button>
-                </div>
+                <div id="react-root"></div>
             </main>
         </div>
 
@@ -80,6 +57,70 @@
         </div>
     </div>
 
+    <script type="text/babel" src="src/components/TarjetaEspecialidad.jsx"></script>
+    <script type="text/babel">
+      const { createRoot } = ReactDOM;
+      const { motion } = framerMotion;
+      const { Stethoscope, Syringe, Baby, Venus, Ambulance, HeartPulse } = lucideReact;
+
+      function ProgressBar({ progress, due }) {
+        return (
+          <div id="progress-container" className="px-4">
+            <div id="progress-bar" className="h-2 bg-gray-200 rounded mb-2 dark:bg-gray-700">
+              <motion.div id="progress-fill" className="h-full bg-blue-500" animate={{ width: progress + '%' }} transition={{ duration: 0.5 }} />
+            </div>
+            <div id="progress-text" className="text-sm text-gray-500 dark:text-gray-300">{due} tarjeta{due !== 1 ? 's' : ''} por repasar hoy</div>
+          </div>
+        );
+      }
+
+      function SpecialtyGrid({ onSelect }) {
+        const data = [
+          { key: 'medicina', label: 'Medicina Interna', icon: Stethoscope },
+          { key: 'cirugia', label: 'Cirugía', icon: Syringe },
+          { key: 'pediatria', label: 'Pediatría', icon: Baby },
+          { key: 'ginecologia', label: 'Ginecología y Obstetricia', icon: Venus },
+          { key: 'atls', label: 'ATLS', icon: Ambulance },
+          { key: 'acls', label: 'ACLS', icon: HeartPulse }
+        ];
+        return (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-8 px-4">
+            {data.map(item => (
+              <TarjetaEspecialidad key={item.key} icon={item.icon} label={item.label} onClick={() => onSelect(item.key)} />
+            ))}
+          </div>
+        );
+      }
+
+      function HomeApp() {
+        const [progress, setProgress] = React.useState(0);
+        const [due, setDue] = React.useState(0);
+
+        React.useEffect(() => {
+          window.updateProgressUI = (p, d) => {
+            setProgress(p);
+            setDue(d);
+          };
+        }, []);
+
+        return (
+          <div>
+            <ProgressBar progress={progress} due={due} />
+            {due === 0 ? (
+              <div className="text-center mt-4" id="empty-state">
+                <p>Sin tarjetas hoy</p>
+                <button id="import-button" className="btn mt-2">Importar mazos</button>
+              </div>
+            ) : (
+              <SpecialtyGrid onSelect={startStudySession} />
+            )}
+          </div>
+        );
+      }
+
+      const root = createRoot(document.getElementById('react-root'));
+      root.render(<HomeApp />);
+    </script>
     <script src="app.js" type="module"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "enarm",
+  "version": "1.0.0",
+  "dependencies": {
+    "framer-motion": "^11.0.0",
+    "lucide-react": "^0.370.0"
+  }
+}

--- a/src/components/TarjetaEspecialidad.jsx
+++ b/src/components/TarjetaEspecialidad.jsx
@@ -1,0 +1,17 @@
+const { motion } = window.framerMotion || {};
+
+function TarjetaEspecialidad({ icon: Icon, label, onClick }) {
+  return (
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.96 }}
+      onClick={onClick}
+      className="border border-blue-500 rounded-xl p-4 bg-gradient-to-br from-white via-gray-50 to-gray-100 shadow-md hover:shadow-lg dark:from-gray-700 dark:via-gray-800 dark:to-gray-900 dark:border-blue-400 flex flex-col items-center"
+    >
+      <Icon className="w-8 h-8 text-blue-500 dark:text-blue-400" />
+      <span className="mt-2 font-medium text-center">{label}</span>
+    </motion.button>
+  );
+}
+
+window.TarjetaEspecialidad = TarjetaEspecialidad;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  darkMode: 'class',
+  content: []
+};


### PR DESCRIPTION
## Summary
- add package.json for new UI dependencies
- enable Tailwind dark mode
- create `TarjetaEspecialidad` component with framer-motion effects
- refactor home screen to render React components
- animate progress bar and add empty state message
- sync theme toggler with Tailwind dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f095083b48328a04763ce2a2b51eb